### PR TITLE
Fasta Adjustment

### DIFF
--- a/reworkedmain.py
+++ b/reworkedmain.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
 from typing import Sequence
+from numpy import float64
 import pandas as pd
 from Bio import SeqIO
 import os
@@ -18,41 +19,41 @@ from pandas.core.frame import DataFrame
 
 
 #Modifiable Values
-csv_file_path = 
-fasta_file_path = 
+csv_file_path = r"C:\Users\penot\Desktop\Test\proteome.csv"
+fasta_file_path = r'C:\Users\penot\Desktop\Test\81287.fna'
 columns = ['ProteinID', 'BE_D_RPKM-relative']
-excel_df = pd.read_csv(csv_file_path, sep =",", usecols=columns).replace('#VALUE!', 0) #Stores dataframe
+excel_df = pd.read_csv(csv_file_path, sep =",", usecols=columns).replace('#VALUE!', 1) #Stores dataframe
 #----------------------------------------------------------------------------------------------
 
 finalseqcount = {'A': 0, 'C': 0, 'D': 0, 'E': 0, 'F': 0, 'G': 0, 'H': 0, 'I': 0, 'K': 0, 'L': 0, 'M': 0, 'N': 0, 'P': 0, 'Q': 0, 'R': 0, 'S': 0, 'T': 0, 'V': 0, 'W': 0, 'Y': 0}
 nucleobasecount = {'A': 0, 'G':0, 'C': 0, 'T': 0, 'U': 0}
 
 with open(os.path.join(pathlib.Path(__file__).parent.resolve(),'AminoAcids.json')) as json_file: #Opens a JSON of amino acids since the translation returns protien sequence
-    data = json.load(json_file)
+    amino_acid_data = json.load(json_file)
 with open(os.path.join(pathlib.Path(__file__).parent.resolve(),'Nucleobases.json')) as json_file: #Opens a JSON of amino acids since the translation returns protien sequence
     nucleobase_data = json.load(json_file)
 
 #------------------------------------------------------------------------------------------------
 
 
-def sequence_handler_DNARNA(entry):
+def sequence_handler_DNARNA(entry) -> int:
     """
     Meant to take an already parsed SeqRecord entry from a fasta. Will take in RNA or DNA fasta files.
 
     Returns PCount, NCount and CCount.
     """
-    PCount = 0 #Initialize PCount
+    PCount = 0 #// Initialize PCount
     PCount = len(str(entry.seq))
 
-    for i in entry.seq: #Logs nucleobases
-        if i in nucleobasecount: #nucleobases for RNA/DNA
+    for i in entry.seq: #// Logs nucleobases
+        if i in nucleobasecount: #// nucleobases for RNA/DNA
             nucleobasecount[i] = nucleobasecount[i] + 1
 
     NCount = 0
     for i in nucleobasecount.keys():
-        for key in data:
-            if i == key in data:
-                NCount = NCount + (nucleobasecount[i]*data[key][2]) #Index 2 is the Nitrogen count of each Acid
+        for key in amino_acid_data:
+            if i == key in amino_acid_data:
+                NCount = NCount + (nucleobasecount[i]*nucleobase_data[key][2]) #Index 2 is the Nitrogen count of each Acid
     CCount = 0
     for i in nucleobasecount.keys():
         for key in nucleobase_data:
@@ -63,7 +64,7 @@ def sequence_handler_DNARNA(entry):
 
 
 
-def sequence_handler_AA(entry):
+def sequence_handler_AA(entry) -> int:
     """
     Meant to take an already parsed SeqRecord entry from a fasta.
 
@@ -74,15 +75,15 @@ def sequence_handler_AA(entry):
             finalseqcount[i] = finalseqcount[i] + 1
 
     NCount = 0
-    for i in finalseqcount.keys(): ##finalseqcount is for AA values
-        for key in data:
-            if i == key in data:
-                NCount = NCount + (finalseqcount[i]*data[key][2]) #Index 2 is the Nitrogen count of each Acid
+    for i in finalseqcount.keys(): ##/ finalseqcount is for AA values
+        for key in amino_acid_data:
+            if i == key in amino_acid_data:
+                NCount = NCount + (finalseqcount[i]*amino_acid_data[key][2]) #Index 2 is the Nitrogen count of each Acid
     CCount = 0
     for i in finalseqcount.keys():
-        for key in data:
-            if i == key in nucleobase_data:
-                CCount = CCount + (finalseqcount[i]*data[key][0]) #Index 0 is Carbon
+        for key in amino_acid_data:
+            if i == key in amino_acid_data:
+                CCount = CCount + (finalseqcount[i]*amino_acid_data[key][0]) #Index 0 is Carbon
 
     return NCount, CCount
 
@@ -96,13 +97,15 @@ for seq_entry in SeqIO.parse(fasta_file_path, "fasta"):
         if str(ProteinID).endswith(seq_entry.id): # //Check if iterated value matches the file
             filtered_row = excel_df.loc[excel_df["ProteinID"]==ProteinID].to_dict('list')
             RPKM = filtered_row["BE_D_RPKM-relative"][0] #//Stores sequences RPKM value
-            return_values = sequence_handler_DNARNA(seq_entry) 
+            return_values = sequence_handler_DNARNA(seq_entry) #// returns tuple of values
 
             if Seq_type == "1": #// No RPKM adjustment needed for DNA
-                Adjusted_Values[str(ProteinID)]= list(return_values)
-            elif Seq_type == "2" or "3": #// This adds a check to skip trying to adjust by NULL values
-                if float(RPKM) > 0: #// Since pandas is replacing data with 0, we don't want it messing with RPKM values
-                    Adjusted_Values[str(ProteinID)] = #placeholder for RPKM adjustment calculation
-                else:
-                    Adjusted_Values[str(ProteinID)] = list(return_values)
+                Adjusted_Values[str(ProteinID)] = list(return_values)
+                
+            elif Seq_type == "2" or "3": # //apply RPKM adjustment
+                adjust = [float64(RPKM)*float64(i) for i in list(return_values)] #// Maybe overkill but float64 probably prevents what i assume was overflowing?
+                Adjusted_Values[str(ProteinID)] = adjust
 
+with open('Results.json', 'a',encoding="utf-8") as file:
+    json.dump(Adjusted_Values, file)
+print("Finished. Result file dumped.")

--- a/reworkedmain.py
+++ b/reworkedmain.py
@@ -1,18 +1,29 @@
 import pathlib
 import re
 from typing import Sequence
+import pandas as pd
 from Bio import SeqIO
 import os
-from Bio.Seq import Seq, translate
-from Bio.SeqRecord import SeqRecord
 from Bio.SeqUtils.ProtParam import ProteinAnalysis
 import json
-from alive_progress import alive_bar; import time, logging
+from pandas.core.frame import DataFrame
 
-print("--------------") #
-#Global Variables
 
-PCount = 0 # Phosphorous count will be sum of sequence length after translating, since this is when the phosphate groups show up
+
+# This FASTA sequencer by default will take in the .csv file pointed to under the fasta_file variable.
+# You will need to point to your own file, and modify the columns variable according to the names you want.
+# This is mostly intended to handle two columns, one with the ID and the RPKM value for gene-expression adjustments.
+
+
+
+
+#Modifiable Values
+csv_file_path = 
+fasta_file_path = 
+columns = ['ProteinID', 'BE_D_RPKM-relative']
+excel_df = pd.read_csv(csv_file_path, sep =",", usecols=columns).replace('#VALUE!', 0) #Stores dataframe
+#----------------------------------------------------------------------------------------------
+
 finalseqcount = {'A': 0, 'C': 0, 'D': 0, 'E': 0, 'F': 0, 'G': 0, 'H': 0, 'I': 0, 'K': 0, 'L': 0, 'M': 0, 'N': 0, 'P': 0, 'Q': 0, 'R': 0, 'S': 0, 'T': 0, 'V': 0, 'W': 0, 'Y': 0}
 nucleobasecount = {'A': 0, 'G':0, 'C': 0, 'T': 0, 'U': 0}
 
@@ -21,241 +32,77 @@ with open(os.path.join(pathlib.Path(__file__).parent.resolve(),'AminoAcids.json'
 with open(os.path.join(pathlib.Path(__file__).parent.resolve(),'Nucleobases.json')) as json_file: #Opens a JSON of amino acids since the translation returns protien sequence
     nucleobase_data = json.load(json_file)
 
-def sequence_handler_Translate_RNA(files, filename):
-    fileparse = SeqIO.parse(files, "fasta")
-    bytecount = os.stat(files).st_size #Byte size for alive_bar
-    with alive_bar(bytecount) as bar:
-        for entry in fileparse:
-            PCount = PCount + len(str(entry.seq)) #Takes the length of the entry before it it translated
-            sequences = Seq(str(entry.seq)).translate() #Translates each entry into amino acids
-            analyzed_seq = ProteinAnalysis(str(sequences))
-            analyzed_seq.count_amino_acids() #Stores amino acid count in dict
-
-            bar()
-
-            for i in entry.seq: #Logs nucleobases
-                if i in nucleobasecount:
-                    nucleobasecount[i] = nucleobasecount[i] + 1
-            bar()
-
-            for key in finalseqcount: #Logs amino acids
-                if key in analyzed_seq.amino_acids_content: #Dictionary content from .count_amino_acids()
-                    finalseqcount[key] = finalseqcount[key] + analyzed_seq.amino_acids_content[key]
-            bar()
-    bar()
+#------------------------------------------------------------------------------------------------
 
 
-    print("Finished.")
-    print("\n")
+def sequence_handler_DNARNA(entry):
+    """
+    Meant to take an already parsed SeqRecord entry from a fasta. Will take in RNA or DNA fasta files.
 
-    print("Your final amino acid counts are: \n")
-    print(finalseqcount)
+    Returns PCount, NCount and CCount.
+    """
+    PCount = 0 #Initialize PCount
+    PCount = len(str(entry.seq))
 
-    print("Your final nucleobase counts are: \n") #Nucleobases for RNA/DNA
-    print(nucleobasecount)
+    for i in entry.seq: #Logs nucleobases
+        if i in nucleobasecount: #nucleobases for RNA/DNA
+            nucleobasecount[i] = nucleobasecount[i] + 1
 
-
-    NCount = 0 #Counts nitrogens
-    for i in finalseqcount.keys():
+    NCount = 0
+    for i in nucleobasecount.keys():
         for key in data:
             if i == key in data:
-                NCount = NCount + (finalseqcount[i]*data[key][2]) #Index 2 is the Nitrogen count of each Acid
+                NCount = NCount + (nucleobasecount[i]*data[key][2]) #Index 2 is the Nitrogen count of each Acid
     CCount = 0
     for i in nucleobasecount.keys():
         for key in nucleobase_data:
             if i == key in nucleobase_data:
-                CCount = CCount + (nucleobasecount[i]*6) + (nucleobasecount[i]*nucleobase_data[key][0])
+                CCount = CCount + (nucleobasecount[i]*nucleobase_data[key][0]) #Index 0 is Carbon
+    return PCount, NCount, CCount
 
 
 
 
-def sequence_handler_RNA(files, filename):
-    fileparse = SeqIO.parse(files, "fasta")
-    bytecount = os.stat(files).st_size #Byte size for alive_bar
-    with alive_bar(bytecount) as bar:
-        for entry in fileparse:
-            PCount = PCount + len(str(entry.seq)) #Takes the length of the entry before it it translated
-            sequences = Seq(str(entry.seq)) #Leaves sequence as-is
-            analyzed_seq = ProteinAnalysis(str(sequences))
-            analyzed_seq.count_amino_acids() #Stores amino acid count in dict
+def sequence_handler_AA(entry):
+    """
+    Meant to take an already parsed SeqRecord entry from a fasta.
 
-            bar()
+    Returns NCount and CCount.
+    """
+    for i in entry.seq: #Logs nucleobases
+        if i in finalseqcount:
+            finalseqcount[i] = finalseqcount[i] + 1
 
-            for i in entry.seq: #Logs nucleobases
-                if i in nucleobasecount:
-                    nucleobasecount[i] = nucleobasecount[i] + 1
-            bar()
-
-            for key in finalseqcount: #Logs amino acids
-                if key in analyzed_seq.amino_acids_content: #Dictionary content from .count_amino_acids()
-                    finalseqcount[key] = finalseqcount[key] + analyzed_seq.amino_acids_content[key]
-            bar()
-    bar()
-
-
-    print("Finished.")
-    print("\n")
-
-    print("Your final amino acid counts are: \n")
-    print(finalseqcount)
-
-    print("Your final nucleobase counts are: \n") #Nucleobases for RNA/DNA
-    print(nucleobasecount)
-
-
-    NCount = 0 #Counts nitrogens
-    for i in finalseqcount.keys():
+    NCount = 0
+    for i in finalseqcount.keys(): ##finalseqcount is for AA values
         for key in data:
             if i == key in data:
                 NCount = NCount + (finalseqcount[i]*data[key][2]) #Index 2 is the Nitrogen count of each Acid
     CCount = 0
-    for i in nucleobasecount.keys():
-        for key in nucleobase_data:
-            if i == key in nucleobase_data:
-                CCount = CCount + (nucleobasecount[i]*6) + (nucleobasecount[i]*nucleobase_data[key][0])
-    with open("rna_results_'{}'.txt".format(filename), "x") as results:
-        results.write("Nucleobase count:\n")
-        results.write(str(nucleobasecount))
-        results.write("\n")
-        results.write("Phosphorous count: \n")
-        results.write(str(PCount))
-        results.write("\n")
-        results.write("Nitrogen count: \n")
-        results.write(str(NCount))
-        results.write("\n")
-        results.write("Carbon count: \n")
-        results.write(str(CCount))
-
-
-
-def sequence_handler_DNA(files, filename):
-    fileparse = SeqIO.parse(files, "fasta")
-    bytecount = os.stat(files).st_size #Byte size for alive_bar
-    with alive_bar(bytecount) as bar:
-        for entry in fileparse:
-            PCount = PCount + len(str(entry.seq)) #Takes the length of the entry before it it translated
-            sequences = Seq(str(entry.seq)) #Leaves sequence as-is
-            analyzed_seq = ProteinAnalysis(str(sequences))
-            analyzed_seq.count_amino_acids() #Stores amino acid count in dict
-
-            bar()
-
-            for i in entry.seq: #Logs nucleobases
-                if i in nucleobasecount:
-                    nucleobasecount[i] = nucleobasecount[i] + 1
-            bar()
-
-            for key in finalseqcount: #Logs amino acids
-                if key in analyzed_seq.amino_acids_content: #Dictionary content from .count_amino_acids()
-                    finalseqcount[key] = finalseqcount[key] + analyzed_seq.amino_acids_content[key]
-            bar()
-    bar()
-
-
-    print("Finished.")
-    print("\n")
-
-    print("Your final amino acid counts are: \n")
-    print(finalseqcount)
-
-    print("Your final nucleobase counts are: \n") #Nucleobases for RNA/DNA
-    print(nucleobasecount)
-
-
-    NCount = 0 #Counts nitrogens
     for i in finalseqcount.keys():
         for key in data:
-            if i == key in data:
-                NCount = NCount + (finalseqcount[i]*data[key][2]) #Index 2 is the Nitrogen count of each Acid
-    CCount = 0
-    for i in nucleobasecount.keys():
-        for key in nucleobase_data:
             if i == key in nucleobase_data:
-                CCount = CCount + (nucleobasecount[i]*6) + (nucleobasecount[i]*nucleobase_data[key][0])
-    with open("dna_results_'{}'.txt".format(filename), "x") as results:
-        results.write("Nucleobase count:\n")
-        results.write(str(nucleobasecount))
-        results.write("\n")
-        results.write("Phosphorous count: \n")
-        results.write(str(PCount))
-        results.write("\n")
-        results.write("Nitrogen count: \n")
-        results.write(str(NCount))
-        results.write("\n")
-        results.write("Carbon count: \n")
-        results.write(str(CCount))
+                CCount = CCount + (finalseqcount[i]*data[key][0]) #Index 0 is Carbon
+
+    return NCount, CCount
 
 
 
-def sequence_handler_AA(files, filename):
-    fileparse = SeqIO.parse(files, "fasta")
-    bytecount = os.stat(files).st_size #Byte size for alive_bar
-    with alive_bar(bytecount) as bar:
-        for entry in fileparse:
-            sequences = Seq(str(entry.seq)) #Leaves sequence as-is
-            analyzed_seq = ProteinAnalysis(str(sequences))
-            analyzed_seq.count_amino_acids() #Stores amino acid count in dict
+Seq_type = input("Specify if your sequence type is\n[1]DNA\n[2]RNA\n[3]AA\n")
 
-            bar()
+Adjusted_Values = {} #Vaules stored here will be ready for RPKM adjustment
+for seq_entry in SeqIO.parse(fasta_file_path, "fasta"):
+    for ProteinID in excel_df["ProteinID"]: # //Iterates over column ProtienID
+        if str(ProteinID).endswith(seq_entry.id): # //Check if iterated value matches the file
+            filtered_row = excel_df.loc[excel_df["ProteinID"]==ProteinID].to_dict('list')
+            RPKM = filtered_row["BE_D_RPKM-relative"][0] #//Stores sequences RPKM value
+            return_values = sequence_handler_DNARNA(seq_entry) 
 
-            for i in entry.seq: #Logs nucleobases
-                if i in nucleobasecount:
-                    nucleobasecount[i] = nucleobasecount[i] + 1
-            bar()
-
-            for key in finalseqcount: #Logs amino acids
-                if key in analyzed_seq.amino_acids_content: #Dictionary content from .count_amino_acids()
-                    finalseqcount[key] = finalseqcount[key] + analyzed_seq.amino_acids_content[key]
-            bar()
-    bar()
-
-
-    print("Finished.")
-    print("\n")
-
-    with open('AminoAcids.json') as json_file: #Opens a JSON of amino acids since the translation returns protien sequence
-        data = json.load(json_file)
-    with open('Nucleobases.json') as json_file: #Opens a JSON of amino acids since the translation returns protien sequence
-        nucleobase_data = json.load(json_file)
-
-    print("Your final amino acid counts are: \n")
-    print(finalseqcount)
-
-    print("Your final nucleobase counts are: \n") #Nucleobases for RNA/DNA
-    print(nucleobasecount)
-
-
-    NCount = 0 #Counts nitrogens
-    for i in finalseqcount.keys():
-        for key in data:
-            if i == key in data:
-                NCount = NCount + (finalseqcount[i]*data[key][2]) #Index 2 is the Nitrogen count of each Acid
-    CCount = 0
-    for i in nucleobasecount.keys():
-        for key in nucleobase_data:
-            if i == key in nucleobase_data:
-                CCount = CCount + (nucleobasecount[i]*6) + (nucleobasecount[i]*nucleobase_data[key][0])
-    with open("AA_results_'{}'.txt".format(filename), "x") as results:
-        results.write("Amino Acid count:\n")
-        results.write(str(finalseqcount))
-        results.write("\n")
-        results.write("Nitrogen count: \n")
-        results.write(str(NCount))
-        results.write("\n")
-        results.write("Carbon count: \n")
-        results.write(str(CCount))
-
-
-
-seq_type = input("Select your sequence type:\n[1]DNA\n[2]RNA\n[3]Count AA Sequence\n")
-
-path = input("Enter the name of the folder that contains all the FASTA files:\n")
-directory = pathlib.Path(__file__).parent.resolve()
-for files in os.listdir(os.path.join(directory, path)):
-    if seq_type == "1":
-        sequence_handler_DNA(os.path.join(directory, path, files), files)
-    if seq_type == "2":
-        sequence_handler_RNA(os.path.join(directory, path, files), files)
-    if seq_type == "3":
-        sequence_handler_AA(os.path.join(directory, path, files), files)
+            if Seq_type == "1": #// No RPKM adjustment needed for DNA
+                Adjusted_Values[str(ProteinID)]= list(return_values)
+            elif Seq_type == "2" or "3": #// This adds a check to skip trying to adjust by NULL values
+                if float(RPKM) > 0: #// Since pandas is replacing data with 0, we don't want it messing with RPKM values
+                    Adjusted_Values[str(ProteinID)] = #placeholder for RPKM adjustment calculation
+                else:
+                    Adjusted_Values[str(ProteinID)] = list(return_values)
 


### PR DESCRIPTION
Merge RNA/DNA functionality into one function, no reason to have two separate handlers.

Fixed calculation issues where AA, RNA and DNA were accessing different json and dictionary values at random.

Reads from CSV files, does not do individual counts anymore, though could easily be adjusted to do so. The loop at the end of the program is mostly what determines *what* is output, the handler functions remain the same as their original counterpart. It shouldn't be hard to adjust as necessary. 

It should be noted that this is not optimized very well and doing calculations using numpy could drastically improve performance should much larger datasets be required to be ran through here.